### PR TITLE
fix: remove legacy `org` and `organization` parameters from `octokit.repos.createFork()` again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,12 +1797,22 @@
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
-      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
       "requires": {
-        "@octokit/types": "^6.13.0",
+        "@octokit/types": "^6.13.1",
         "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.13.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.1.tgz",
+          "integrity": "sha512-UF/PL0y4SKGx/p1azFf7e6j9lB78tVwAFvnHtslzOJ6VipshYks74qm9jjTEDlCyaTmbhbk2h3Run5l0CtCF6A==",
+          "requires": {
+            "@octokit/openapi-types": "^6.0.0"
+          }
+        }
       }
     },
     "@octokit/request": {
@@ -1840,6 +1850,18 @@
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
         "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+      },
+      "dependencies": {
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+          "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^6.13.0",
+            "deprecation": "^2.3.1"
+          }
+        }
       }
     },
     "@octokit/types": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@octokit/core": "^3.2.3",
     "@octokit/plugin-paginate-rest": "^2.6.2",
     "@octokit/plugin-request-log": "^1.0.2",
-    "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+    "@octokit/plugin-rest-endpoint-methods": "5.0.1"
   },
   "devDependencies": {
     "@octokit/auth": "^3.0.1",


### PR DESCRIPTION
fixes #45
