### PR TITLE
docs: fix assignment in plugin example

### DIFF
--- a/docs/src/pages/api/08_plugins.md
+++ b/docs/src/pages/api/08_plugins.md
@@ -6,7 +6,7 @@ You can customize and extend Octokit’s functionality using plugins
 
 ```js
 // index.js
-const Octokit = require("@octokit/rest");
+const { Octokit } = require("@octokit/rest");
 const MyOctokit = Octokit.plugin(
   require("./lib/my-plugin"),
   require("octokit-plugin-example")


### PR DESCRIPTION
This example in the docs needs to use destructuring assignment to work. I know this code wouldn't actually run as-is but did trip me up in a fury of copy-pasting.