### PR TITLE
fix(deps): bump minimal version of `@octokit/plugin-paginate-rest` to `v2.16.4` to prevent typescript compile errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "repository": "github:octokit/rest.js",
   "dependencies": {
     "@octokit/core": "^3.5.1",
-    "@octokit/plugin-paginate-rest": "^2.16.0",
+    "@octokit/plugin-paginate-rest": "^2.16.4",
     "@octokit/plugin-request-log": "^1.0.4",
     "@octokit/plugin-rest-endpoint-methods": "5.11.3"
   },


### PR DESCRIPTION
Update package "@octokit/plugin-paginate-rest" to 2.16.4.  While npm can update the package, it does not always do so and Typescript gets compile errors such as:

Property 'GET /user/{username}/packages' does not exist on type 'Endpoints'.

This should address issue #115 without user intervention required.