### PR TITLE
docs: Fix gatsby warnings during build

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -5,7 +5,6 @@ module.exports = {
     title: `Octokit.js`,
   },
   plugins: [
-    `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,6 @@
       "devDependencies": {
         "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^3.0.0",
         "gatsby": "^4.0.0",
-        "gatsby-plugin-react-helmet": "^5.0.0",
         "gatsby-plugin-typography": "^4.0.0",
         "gatsby-remark-prismjs": "^6.0.0",
         "gatsby-source-filesystem": "^4.0.0",
@@ -9937,22 +9936,6 @@
       },
       "peerDependencies": {
         "gatsby": "^4.0.0-next"
-      }
-    },
-    "node_modules/gatsby-plugin-react-helmet": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.23.0.tgz",
-      "integrity": "sha512-xS8WjuyRoeYv8U2YSHNfnF1o4LPq2YMY6Za04tGnGd+g3C8dSXcQO6mP4Pr5jDzFxOpCitwAG7C22peK8a/zIQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^4.0.0-next",
-        "react-helmet": "^5.1.3 || ^6.0.0"
       }
     },
     "node_modules/gatsby-plugin-typescript": {
@@ -27613,15 +27596,6 @@
         "gatsby-telemetry": "^3.23.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21"
-      }
-    },
-    "gatsby-plugin-react-helmet": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.23.0.tgz",
-      "integrity": "sha512-xS8WjuyRoeYv8U2YSHNfnF1o4LPq2YMY6Za04tGnGd+g3C8dSXcQO6mP4Pr5jDzFxOpCitwAG7C22peK8a/zIQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.15.4"
       }
     },
     "gatsby-plugin-typescript": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -21,7 +21,6 @@
         "react": "^17.0.2",
         "react-debounce-render": "^8.0.0",
         "react-dom": "^17.0.2",
-        "react-helmet": "^6.0.0",
         "react-typography": "^0.16.20",
         "title-case": "^3.0.2",
         "typography": "^0.16.21",
@@ -15997,27 +15996,6 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "dev": true
-    },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -16043,15 +16021,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-side-effect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "dev": true,
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-typography": {
@@ -32136,24 +32105,6 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "dev": true
-    },
-    "react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -32177,13 +32128,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
-    },
-    "react-side-effect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "dev": true,
-      "requires": {}
     },
     "react-typography": {
       "version": "0.16.20",

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,6 @@
     "react": "^17.0.2",
     "react-debounce-render": "^8.0.0",
     "react-dom": "^17.0.2",
-    "react-helmet": "^6.0.0",
     "react-typography": "^0.16.20",
     "title-case": "^3.0.2",
     "typography": "^0.16.21",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^3.0.0",
     "gatsby": "^4.0.0",
-    "gatsby-plugin-react-helmet": "^5.0.0",
     "gatsby-plugin-typography": "^4.0.0",
     "gatsby-remark-prismjs": "^6.0.0",
     "gatsby-source-filesystem": "^4.0.0",

--- a/docs/src/components/index-page.js
+++ b/docs/src/components/index-page.js
@@ -38,7 +38,7 @@ export default class IndexPage extends Component {
   render() {
     return (
       <div>
-        <header className={layoutStyles.header}>
+        <header>
           <StaticQuery
             query={graphql`
               {
@@ -62,7 +62,7 @@ export default class IndexPage extends Component {
               const { currentVersion } = data.sitePlugin.pluginOptions;
               return (
                 <>
-                  <div className={layoutStyles.dropdownSelect}>
+                  <div>
                     <select
                       value={this.props.version}
                       onChange={this.onVersionChange}

--- a/docs/src/components/template.js
+++ b/docs/src/components/template.js
@@ -1,5 +1,4 @@
-import React, { Fragment } from "react";
-import { Helmet } from "react-helmet";
+import React from "react";
 
 import { graphql } from "gatsby";
 
@@ -7,15 +6,18 @@ import IndexPage from "./index-page";
 
 export default ({ data, pageContext }) => {
   return (
-    <Fragment>
-      <Helmet>
-        <meta charset="utf-8" />
-        <title>octokit/rest.js</title>
-      </Helmet>
       <IndexPage version={pageContext.version} data={data} />
-    </Fragment>
   );
 };
+
+export function Head() {
+  return (
+    <>
+        <meta charset="utf-8" />
+        <title>octokit/rest.js</title>
+    </>
+  );
+}
 
 export const query = graphql`
   query TemplateQuery($version: String, $endpoints: String) {

--- a/docs/src/components/template.js
+++ b/docs/src/components/template.js
@@ -5,16 +5,14 @@ import { graphql } from "gatsby";
 import IndexPage from "./index-page";
 
 export default ({ data, pageContext }) => {
-  return (
-      <IndexPage version={pageContext.version} data={data} />
-  );
+  return <IndexPage version={pageContext.version} data={data} />;
 };
 
 export function Head() {
   return (
     <>
-        <meta charset="utf-8" />
-        <title>octokit/rest.js</title>
+      <meta charset="utf-8" />
+      <title>octokit/rest.js</title>
     </>
   );
 }

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,18 +1,21 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { graphql } from "gatsby";
 
 export default function Index(props) {
   const { currentVersion } = props.data.sitePlugin.pluginOptions;
+  return <a href={`${currentVersion}/`} >Redirecting to /{currentVersion}...</a>;
+}
+
+export function Head(props) {
+  const { currentVersion } = props.data.sitePlugin.pluginOptions;
   return (
-    <Helmet>
+    <>
       {/* redirect the root path "/" to the current version */}
-      <meta http-equiv="refresh" content={`0;url=./${currentVersion}`} />
-      <script>
-        if (window.location.hash) (window.location.pathname += "v16/")
-      </script>
-    </Helmet>
+      <meta http-equiv="refresh" content={`0;url=./${currentVersion}/`} />
+      <script>{`if (window.location.hash) { window.location.pathname += "${currentVersion}/"; }`}</script>
+    </>
   );
+
 }
 
 export const pageQuery = graphql`

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -3,7 +3,7 @@ import { graphql } from "gatsby";
 
 export default function Index(props) {
   const { currentVersion } = props.data.sitePlugin.pluginOptions;
-  return <a href={`${currentVersion}/`} >Redirecting to /{currentVersion}...</a>;
+  return <a href={`${currentVersion}/`}>Redirecting to /{currentVersion}...</a>;
 }
 
 export function Head(props) {
@@ -15,7 +15,6 @@ export function Head(props) {
       <script>{`if (window.location.hash) { window.location.pathname += "${currentVersion}/"; }`}</script>
     </>
   );
-
 }
 
 export const pageQuery = graphql`


### PR DESCRIPTION
Gatsby has built in support for modifying the <head> element now, and there were unused className bindings causing warnings from one of the css modules.