### PR TITLE
fix: Enable the linter scripts to run on powershell

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   "scripts": {
     "build": "pika-pack build",
     "coverage": "nyc report --reporter=html && open coverage/index.html",
-    "lint": "prettier --check '{src,test}/**/*.{js,json,ts}' 'docs/*.js' docs/package.json 'docs/src/**/*' *.md package.json",
-    "lint:fix": "prettier --write '{src,test}/**/*.{js,json,ts}' 'docs/*.js' docs/package.json 'docs/src/**/*' *.md package.json",
+    "lint": "prettier --check \"{src,test}/**/*.{js,json,ts}\" \"docs/*.js\" docs/package.json \"docs/src/**/*\" *.md package.json",
+    "lint:fix": "prettier --write \"{src,test}/**/*.{js,json,ts}\" \"docs/*.js\" docs/package.json \"docs/src/**/*\" *.md package.json",
     "start-fixtures-server": "octokit-fixtures-server",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",


### PR DESCRIPTION
Powershell does not like the single quotes and my last PR, the local lint-check failed with a false success exit code while complaining about not finding any files to check. Changing the quotes in the linter scripts to regular quotes solved the issue.