### PR TITLE
fix: export type only `RestEndpointMethodTypes`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Octokit as Core } from "@octokit/core";
 import { requestLog } from "@octokit/plugin-request-log";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
 import { legacyRestEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
-export { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 
 import { VERSION } from "./version";
 
@@ -15,3 +15,5 @@ export const Octokit = Core.plugin(
 });
 
 export type Octokit = InstanceType<typeof Octokit>;
+export type { RestEndpointMethodTypes };
+  

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Octokit as Core } from "@octokit/core";
 import { requestLog } from "@octokit/plugin-request-log";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
 import { legacyRestEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
-import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+export type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 
 import { VERSION } from "./version";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,3 @@ export const Octokit = Core.plugin(
 });
 
 export type Octokit = InstanceType<typeof Octokit>;
-export type { RestEndpointMethodTypes };
-  


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #298

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Reexport of type `RestEndpointMethodTypes` appears in the js dist.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Only re-export it as type.


### Other information
<!-- Any other information that is important to this PR  -->

This also breaks Vite when trying to import octokit in the client side. 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

