### PR TITLE
fix(deps): revert breaking dependency changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^7.0.0",
+        "@octokit/plugin-paginate-rest": "^6.1.2",
         "@octokit/plugin-request-log": "^1.0.4",
         "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
       },
@@ -2015,19 +2015,24 @@
       "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.2.tgz",
-      "integrity": "sha512-Jx8KuKqEAVRsK6fMzZKv3h6UH9/NRDHsDRtUAROqqmZlCptM///Uef7A1ViZ/cbDplekz7VbDWdFLAZ/mpuDww==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "dependencies": {
-        "@octokit/tsconfig": "^2.0.0",
-        "@octokit/types": "^9.3.2"
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       },
       "peerDependencies": {
         "@octokit/core": ">=4"
       }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
     "node_modules/@octokit/plugin-request-log": {
       "version": "1.0.4",
@@ -2115,12 +2120,13 @@
     "node_modules/@octokit/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ=="
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.1.tgz",
+      "integrity": "sha512-zfJzyXLHC42sWcn2kS+oZ/DRvFZBYCCbfInZtwp1Uopl1qh6pRg4NSP/wFX1xCOpXvEkctiG1sxlSlkZmzvxdw==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
@@ -2258,6 +2264,28 @@
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
       }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.0.tgz",
+      "integrity": "sha512-vbKrs/VZ8Sx4T9IxxxnksL969L705GkcgrzdlJoF0rVxjTfetYUmaGzD9oUvNhbx9MrxOZreYJlpm1BySe2Z9w==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.3.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=4"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+      "dev": true
     },
     "node_modules/@semantic-release/github/node_modules/debug": {
       "version": "4.3.4",
@@ -15496,12 +15524,19 @@
       "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.2.tgz",
-      "integrity": "sha512-Jx8KuKqEAVRsK6fMzZKv3h6UH9/NRDHsDRtUAROqqmZlCptM///Uef7A1ViZ/cbDplekz7VbDWdFLAZ/mpuDww==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "requires": {
-        "@octokit/tsconfig": "^2.0.0",
-        "@octokit/types": "^9.3.2"
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
+      },
+      "dependencies": {
+        "@octokit/tsconfig": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+          "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
+        }
       }
     },
     "@octokit/plugin-request-log": {
@@ -15564,12 +15599,13 @@
     "@octokit/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ=="
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "dev": true
     },
     "@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.1.tgz",
+      "integrity": "sha512-zfJzyXLHC42sWcn2kS+oZ/DRvFZBYCCbfInZtwp1Uopl1qh6pRg4NSP/wFX1xCOpXvEkctiG1sxlSlkZmzvxdw==",
       "requires": {
         "@octokit/openapi-types": "^18.0.0"
       }
@@ -15677,6 +15713,22 @@
         "url-join": "^5.0.0"
       },
       "dependencies": {
+        "@octokit/plugin-paginate-rest": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.0.tgz",
+          "integrity": "sha512-vbKrs/VZ8Sx4T9IxxxnksL969L705GkcgrzdlJoF0rVxjTfetYUmaGzD9oUvNhbx9MrxOZreYJlpm1BySe2Z9w==",
+          "dev": true,
+          "requires": {
+            "@octokit/tsconfig": "^1.0.2",
+            "@octokit/types": "^9.3.1"
+          }
+        },
+        "@octokit/tsconfig": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+          "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+          "dev": true
+        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "repository": "github:octokit/rest.js",
   "dependencies": {
     "@octokit/core": "^4.2.1",
-    "@octokit/plugin-paginate-rest": "^7.0.0",
+    "@octokit/plugin-paginate-rest": "^6.1.2",
     "@octokit/plugin-request-log": "^1.0.4",
     "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
   },


### PR DESCRIPTION
Fixes #318 and removes the breaking dependency changes that prematurely dropped support for Node 14/16. 