### PR TITLE
test(refactor): use 'toEqual' instead of 'toStrictEqual' for Responses

### DIFF
--- a/test/scenarios/errors.test.ts
+++ b/test/scenarios/errors.test.ts
@@ -24,16 +24,13 @@ describe("api.github.com", () => {
         expect(error.message).toEqual(
           `Validation Failed: {"resource":"Label","code":"invalid","field":"color"}`,
         );
-        // To-Do: Figure out why the objects are not strictly equal
-        expect(JSON.stringify(error.response.data.errors)).toStrictEqual(
-          JSON.stringify([
-            {
-              resource: "Label",
-              code: "invalid",
-              field: "color",
-            },
-          ]),
-        );
+        expect(error.response.data.errors).toEqual([
+          {
+            resource: "Label",
+            code: "invalid",
+            field: "color",
+          },
+        ]);
         expect(error.response.data.documentation_url).toMatch(
           new RegExp("rest/reference/issues#create-a-label"),
         );


### PR DESCRIPTION
<!-- Issues are required for both bug fixes and features. -->
Resolves #328

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toStrictEqual` with `JSON.stringify`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toEqual`


### Other information
<!-- Any other information that is important to this PR  -->
More context in https://github.com/octokit/core.js/issues/588

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type
`Type: Maintenance`

----

