### PR TITLE
docs: replace references to skypack with esm.sh

### DIFF
--- a/docs/src/pages/api/00_usage.md
+++ b/docs/src/pages/api/00_usage.md
@@ -7,11 +7,11 @@ Import the Octokit constructor based on your platform.
 ### Browsers
 
 <div>
-Load <code>@octokit/rest</code> directly from <a href="https://cdn.skypack.dev">cdn.skypack.dev</a>
+Load <code>@octokit/rest</code> directly from <a href="https://esm.sh">esm.sh</a>
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.skypack.dev/@octokit/rest";
+  import { Octokit } from "https://esm.sh/@octokit/rest";
 </script>
 ```
 


### PR DESCRIPTION
Related:
#317 updated the top-level readme to replace skypack with esm.sh

#327 was closed indicating that skypack isn't maintained any more.

### Before the change?

The docs at https://octokit.github.io/rest.js/v19 recommend using skypack to load this library in a browser. But this package does not load, logging a build error to the console when you try. 

### After the change?

Documentation should show a working URL in the example


### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [X] No
