### PR TITLE
ci: don't put a comment on PRs from dependabot or renovate

### DIFF
--- a/.github/workflows/immediate-response.yml
+++ b/.github/workflows/immediate-response.yml
@@ -11,6 +11,7 @@ on:
       - opened
 jobs:
   respond-to-issue:
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Determine issue or PR number


### PR DESCRIPTION
As discussed in https://github.com/orgs/octokit/discussions/56, this will help reduce the noise a bit.