### PR TITLE
refactor: use `node:` specifier imports and full relative imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "start-fixtures-server": "octokit-fixtures-server",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",
-    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals test/typescript-validate.ts"
+    "test:typescript": "npx tsc --noEmit --declaration --allowImportingTsExtensions --moduleResolution node16 --module node16 --noUnusedLocals test/typescript-validate.ts"
   },
   "license": "MIT",
   "jest": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { paginateRest } from "@octokit/plugin-paginate-rest";
 import { legacyRestEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 export type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 
-import { VERSION } from "./version";
+import { VERSION } from "./version.js";
 
 export const Octokit = Core.plugin(
   requestLog,

--- a/test/integration/agent-ca/agent-ca-test.js
+++ b/test/integration/agent-ca/agent-ca-test.js
@@ -1,5 +1,5 @@
-const { readFileSync } = require("fs");
-const { resolve } = require("path");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
 const { fetch: undiciFetch, Agent } = require("undici");
 
 const { Octokit } = require("../../..");

--- a/test/integration/smoke.test.ts
+++ b/test/integration/smoke.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { Octokit } from "../../src";
+import { Octokit } from "../../src/index.ts";
 
 describe("Smoke tests", () => {
   it("is a function", () => {

--- a/test/issues/881-redirect-url.test.ts
+++ b/test/issues/881-redirect-url.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { Octokit } from "../../src";
+import { Octokit } from "../../src/index.ts";
 
 describe("https://github.com/octokit/rest.js/issues/881", () => {
   it("returns response.url", () => {

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -2,7 +2,7 @@
 // as installing leakage broke for recent Node versions.
 // We are looking for an alternative.
 const { iterate } = require("leakage");
-const { Octokit } = require("../pkg");
+const { Octokit } = require("../pkg/index.js");
 
 const TestOctokit = Octokit.plugin((octokit) => {
   // skip sending requests altogether

--- a/test/scenarios/add-and-remove-repository-collaborator.test.ts
+++ b/test/scenarios/add-and-remove-repository-collaborator.test.ts
@@ -1,4 +1,4 @@
-import { loadFixture, fixtureToInstance, OctokitType } from "../util";
+import { loadFixture, fixtureToInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let githubUserA: OctokitType;

--- a/test/scenarios/add-and-remove-repository-collaborator.test.ts
+++ b/test/scenarios/add-and-remove-repository-collaborator.test.ts
@@ -1,4 +1,4 @@
-import { loadFixture, fixtureToInstance, OctokitType } from "../util.js";
+import { loadFixture, fixtureToInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let githubUserA: OctokitType;

--- a/test/scenarios/add-labels-to-issue.test.ts
+++ b/test/scenarios/add-labels-to-issue.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/add-labels-to-issue.test.ts
+++ b/test/scenarios/add-labels-to-issue.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/branch-protection.test.ts
+++ b/test/scenarios/branch-protection.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/branch-protection.test.ts
+++ b/test/scenarios/branch-protection.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/create-file.test.ts
+++ b/test/scenarios/create-file.test.ts
@@ -1,6 +1,6 @@
 const btoa = require("btoa-lite");
 
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/create-file.test.ts
+++ b/test/scenarios/create-file.test.ts
@@ -1,6 +1,6 @@
 const btoa = require("btoa-lite");
 
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/create-status.test.ts
+++ b/test/scenarios/create-status.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/create-status.test.ts
+++ b/test/scenarios/create-status.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/errors.test.ts
+++ b/test/scenarios/errors.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/errors.test.ts
+++ b/test/scenarios/errors.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-archive.test.ts
+++ b/test/scenarios/get-archive.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-archive.test.ts
+++ b/test/scenarios/get-archive.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-content.test.ts
+++ b/test/scenarios/get-content.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-content.test.ts
+++ b/test/scenarios/get-content.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-organization.test.ts
+++ b/test/scenarios/get-organization.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-organization.test.ts
+++ b/test/scenarios/get-organization.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-repository.test.ts
+++ b/test/scenarios/get-repository.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/get-repository.test.ts
+++ b/test/scenarios/get-repository.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/labels.test.ts
+++ b/test/scenarios/labels.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/labels.test.ts
+++ b/test/scenarios/labels.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/lock-issue.test.ts
+++ b/test/scenarios/lock-issue.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/lock-issue.test.ts
+++ b/test/scenarios/lock-issue.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/mark-notifications-as-read.test.ts
+++ b/test/scenarios/mark-notifications-as-read.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/mark-notifications-as-read.test.ts
+++ b/test/scenarios/mark-notifications-as-read.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/markdown.test.ts
+++ b/test/scenarios/markdown.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/markdown.test.ts
+++ b/test/scenarios/markdown.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/paginate-issues-async-await.test.ts
+++ b/test/scenarios/paginate-issues-async-await.test.ts
@@ -1,7 +1,7 @@
 // this file is not run directly but instead required in paginate-issues-test.js
 // for Node v10 and higher only
 
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/paginate-issues-async-await.test.ts
+++ b/test/scenarios/paginate-issues-async-await.test.ts
@@ -1,7 +1,7 @@
 // this file is not run directly but instead required in paginate-issues-test.js
 // for Node v10 and higher only
 
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/paginate-issues.test.ts
+++ b/test/scenarios/paginate-issues.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 type IteratorResult = {
   value: {

--- a/test/scenarios/paginate-issues.test.ts
+++ b/test/scenarios/paginate-issues.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 type IteratorResult = {
   value: {

--- a/test/scenarios/project-cards.test.ts
+++ b/test/scenarios/project-cards.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/project-cards.test.ts
+++ b/test/scenarios/project-cards.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/release-assets.test.ts
+++ b/test/scenarios/release-assets.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/release-assets.test.ts
+++ b/test/scenarios/release-assets.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/rename-repository.test.ts
+++ b/test/scenarios/rename-repository.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/rename-repository.test.ts
+++ b/test/scenarios/rename-repository.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/search-issues.test.ts
+++ b/test/scenarios/search-issues.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util.js";
+import { getInstance, OctokitType } from "../util.ts";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/scenarios/search-issues.test.ts
+++ b/test/scenarios/search-issues.test.ts
@@ -1,4 +1,4 @@
-import { getInstance, OctokitType } from "../util";
+import { getInstance, OctokitType } from "../util.js";
 
 describe("api.github.com", () => {
   let octokit: OctokitType;

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -2,7 +2,7 @@ import { Agent } from "node:http";
 
 import { EndpointDefaults } from "@octokit/types";
 
-import { Octokit, RestEndpointMethodTypes } from "../src";
+import { Octokit, RestEndpointMethodTypes } from "../src/index.ts";
 
 // ************************************************************
 // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,4 +1,4 @@
-import { Agent } from "http";
+import { Agent } from "node:http";
 
 import { EndpointDefaults } from "@octokit/types";
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,7 +2,7 @@
 
 import { request } from "@octokit/request";
 
-import { Octokit } from "../src";
+import { Octokit } from "../src/index.ts";
 
 type Unpacked<T> = T extends (infer U)[]
   ? U


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.