### PR TITLE
ci: update docs workflow to use `actions/deploy-pages`

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -3,19 +3,41 @@ name: Update docs on pushes to main
   push:
     branches:
       - main
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   update_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
+          cache-dependency-path:
+            ./docs/package-lock.json
+            ./package-lock.json
       - run: npm ci
       - run: npm --prefix ./docs ci ./docs
       - run: npm run build --prefix ./docs -- --prefix-paths
-      - uses: maxheld83/ghpages@master
-        env:
-          BUILD_DIR: docs/public/
-          GH_PAT: ${{ secrets.OCTOKITBOT_PAT }}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs/public'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: update_docs
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The update docs workflow would be failing
* Used deprecated action

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Use GitHub's own actions for pushing to github pages

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

