### PR TITLE
feat: address ESLint's `no-unresolved` warning

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -54,6 +54,7 @@ async function main() {
         ...pkg,
         files: ["dist-*/**"],
         types: "dist-types/index.d.ts",
+        main: "./dist-src/index.js",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",


### PR DESCRIPTION
Resolves #446

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* ESLint complains about the missing `@octokit/rest` module (see e.g. [here](https://github.com/git-for-windows/setup-git-for-windows-sdk/actions/runs/13587687456/job/37986244497?pr=1108#step:5:11)).

### After the change?

* ESLint no longer complains.

This is achieved by adding the `main` property for backwards-compatibility, needed e.g. when running ESLint.

The change recapitulates what https://github.com/octokit/rest.js/pull/413/commits/aad55f47f1e6348fa3d246697d7503985eff4c06 already did but which was unfortunately reverted in the same PR by https://github.com/octokit/rest.js/pull/413/commits/1b6e5829faaaefb9e4133685f719a56234a304b1 (probably under the incorrect assumption that `exports.default` would be enough as a fall-back).

### Pull request checklist
- Does not apply: Tests for the changes have been added (for bug fixes / features)
- Does not apply: Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

/cc @wolfy1339 @kfcampbell 