### PR TITLE
maint: add v22.x docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22 # This version is known working by the docs
           cache: npm
       - run: npm ci
       - run: npm --prefix ./docs ci ./docs

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -87,7 +87,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-versioned-docs",
       options: {
-        currentVersion: "v21", // configure the path for the current version
+        currentVersion: "v22", // configure the path for the current version
         versions: [
           {
             name: "v16", // the path of the older version
@@ -113,6 +113,11 @@ module.exports = {
             name: "v20", // the path of the older version
             branch: "20.x", // older versions specify a branch name for this repo
             endpoints: "10.x", // ...and one for the endpoint methods
+          },
+          {
+            name: "v21", // the path of the older version
+            branch: "21.x", // older versions specify a branch name for this repo
+            endpoints: "13.x", // ...and one for the endpoint methods
           },
         ],
       },


### PR DESCRIPTION
* Pins the Node version used for the docs update to a known working version
* Bumps the latest version to 22.x
* Adds versioned docs for 21.x