### PR TITLE
docs: add Sourcey-generated REST.js documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 # Pika builds
 pkg/
+# Sourcey generated documentation output
+docs/sourcey/.sourcey/

--- a/docs/sourcey/authentication.md
+++ b/docs/sourcey/authentication.md
@@ -1,0 +1,13 @@
+# Authentication
+
+Create a client with a token supplied through the environment:
+
+```js
+import { Octokit } from "@octokit/rest";
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+const { data } = await octokit.rest.users.getAuthenticated();
+console.log(data.login);
+```
+
+Use least-privilege tokens, never log authorization headers, and rotate credentials according to your organization policy.

--- a/docs/sourcey/configuration.md
+++ b/docs/sourcey/configuration.md
@@ -1,0 +1,13 @@
+# Configuration
+
+A client can be configured with authentication, a custom base URL, request media types, and transport options:
+
+```js
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+  baseUrl: "https://api.github.com",
+  userAgent: "my-service/1.0",
+});
+```
+
+Keep configuration deterministic across environments and inject secrets at runtime.

--- a/docs/sourcey/endpoints.md
+++ b/docs/sourcey/endpoints.md
@@ -1,0 +1,13 @@
+# Endpoint families
+
+The REST client exposes typed methods for common GitHub resources:
+
+- repositories and releases
+- issues, comments, labels, and milestones
+- pull requests, reviews, and files
+- actions workflows and runs
+- organizations, teams, and members
+- users, apps, installations, and codespaces
+- reactions, search, rate limits, and metadata
+
+See the generated endpoint method surface and GitHub REST API reference for exact parameters and response schemas.

--- a/docs/sourcey/errors.md
+++ b/docs/sourcey/errors.md
@@ -1,0 +1,13 @@
+# Errors and retries
+
+Catch request errors and inspect their status and response data:
+
+```js
+try {
+  await octokit.rest.repos.get({ owner: "octokit", repo: "missing" });
+} catch (error) {
+  console.error(error.status, error.response?.data);
+}
+```
+
+Retry only idempotent operations or operations with an explicit idempotency strategy. Respect rate-limit and secondary-rate-limit responses.

--- a/docs/sourcey/examples.md
+++ b/docs/sourcey/examples.md
@@ -1,0 +1,24 @@
+# Examples
+
+List open issues:
+
+```js
+const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+  owner: "octokit",
+  repo: "rest.js",
+  state: "open",
+});
+```
+
+Create an issue:
+
+```js
+await octokit.rest.issues.create({
+  owner: "octokit",
+  repo: "rest.js",
+  title: "Investigate API behaviour",
+  body: "Reproduction details go here.",
+});
+```
+
+Validate user input before using it in endpoint parameters and apply authorization checks in your own service.

--- a/docs/sourcey/installation.md
+++ b/docs/sourcey/installation.md
@@ -1,0 +1,15 @@
+# Installation
+
+Install the package with npm:
+
+```bash
+npm install octokit
+```
+
+For the REST client package:
+
+```bash
+npm install @octokit/rest
+```
+
+The package is ESM-first. Use a current Node.js release and keep credentials outside source control.

--- a/docs/sourcey/introduction.md
+++ b/docs/sourcey/introduction.md
@@ -1,0 +1,12 @@
+# Octokit REST.js
+
+Octokit REST.js is the official GitHub REST API client for Node.js. It provides typed endpoint methods, pagination helpers, request hooks, and consistent request/response handling on top of `@octokit/core`.
+
+## What you can do
+
+- create an authenticated Octokit client
+- call REST endpoints with typed parameters
+- paginate collection endpoints safely
+- inspect response data, headers, and status
+- add request and logging plugins
+- use endpoint helpers for repositories, issues, pull requests, users, organizations, and more

--- a/docs/sourcey/pagination.md
+++ b/docs/sourcey/pagination.md
@@ -1,0 +1,13 @@
+# Pagination
+
+Use `paginate` for collection endpoints instead of manually managing `Link` headers:
+
+```js
+const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+  owner: "octokit",
+  repo: "rest.js",
+  per_page: 100,
+});
+```
+
+For bounded memory usage, pass a map function or an async iterator pattern and impose application-specific limits.

--- a/docs/sourcey/plugins.md
+++ b/docs/sourcey/plugins.md
@@ -1,0 +1,5 @@
+# Plugins and hooks
+
+Octokit supports plugins for pagination, endpoint methods, request logging, and authentication. Compose only the capabilities required by your application.
+
+Request hooks are useful for tracing and retry policy. Redact tokens and personal data before sending logs to an external system.

--- a/docs/sourcey/requests.md
+++ b/docs/sourcey/requests.md
@@ -1,0 +1,14 @@
+# Requests and responses
+
+Endpoint methods follow the GitHub REST API shape. Parameters are validated by TypeScript when using the generated endpoint types.
+
+```js
+const { data, status, headers } = await octokit.rest.repos.get({
+  owner: "octokit",
+  repo: "rest.js",
+});
+
+console.log(status, data.full_name, headers.etag);
+```
+
+Handle non-2xx responses explicitly and preserve request identifiers when diagnosing failures.

--- a/docs/sourcey/security.md
+++ b/docs/sourcey/security.md
@@ -1,0 +1,9 @@
+# Security practices
+
+- store tokens in a secret manager or environment variable
+- use minimal token scopes
+- redact `Authorization` headers and sensitive response fields
+- validate repository, owner, and user inputs
+- respect GitHub rate limits and terms of use
+- pin dependencies and review lockfile changes
+- treat webhook or API content as untrusted input

--- a/docs/sourcey/sourcey.config.ts
+++ b/docs/sourcey/sourcey.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, markdown } from "sourcey";
+
+export default defineConfig({
+  name: "Octokit REST.js",
+  theme: { preset: "default", colors: { primary: "#24292f" } },
+  repo: "https://github.com/octokit/rest.js",
+  editBranch: "main",
+  editBasePath: "docs/sourcey",
+  navigation: {
+    tabs: [{
+      tab: "Guides",
+      slug: "",
+      source: markdown({
+        groups: [
+          { group: "Start Here", pages: ["introduction", "installation", "authentication"] },
+          { group: "Core Usage", pages: ["requests", "pagination", "plugins", "configuration", "examples"] },
+          { group: "Reference", pages: ["endpoints", "errors", "security"] },
+        ],
+      }),
+    }],
+  },
+});


### PR DESCRIPTION
## Summary

- add a maintained Sourcey documentation source/configuration for Octokit REST.js
- cover installation, authentication, requests, pagination, plugins, endpoint families, examples, configuration, errors, and security
- keep authored Markdown/config separate from generated output

The Sourcey build was exercised locally against the pinned fork commit and produced 12 HTML pages with navigation.
